### PR TITLE
Updated conversation.rs for enemy prompt

### DIFF
--- a/code/src/conversation.rs
+++ b/code/src/conversation.rs
@@ -9,6 +9,8 @@ pub struct Hero;
 pub struct Enemy;
 #[derive(Component)]
 pub struct DialogueBox;
+#[derive(Component)]
+pub struct UserInput;
 
 enum ConversationState {
     Introduction,
@@ -69,7 +71,7 @@ pub fn setup_conversation(
         },
         transform: Transform::from_translation(box_position.extend(0.0)),
         ..default()
-    });
+    }).insert(DialogueBox);
 
     commands.spawn_bundle(SpriteBundle {
         sprite: Sprite {
@@ -79,13 +81,12 @@ pub fn setup_conversation(
         },
         transform: Transform::from_translation(box_position_two.extend(0.0)),
         ..default()
-    });
+    }).insert(DialogueBox);
 
     commands.spawn_bundle(Text2dBundle {
         text: Text::from_section("Excuse me neighbor, can I borrow some sugar?", enemy_text_style),
         text_2d_bounds: Text2dBounds {
             size: box_size,
-
         },
         transform: Transform::from_xyz(
             box_position_two.x - box_size.x / 2.0,
@@ -93,13 +94,12 @@ pub fn setup_conversation(
             1.0,
         ),
         ..default()
-    });
+    }).insert(DialogueBox);
     
     commands.spawn_bundle(Text2dBundle {
         text: Text::from_section("Press enter to display input", user_text_style),
         text_2d_bounds: Text2dBounds {
             size: box_size,
-
         },
         transform: Transform::from_xyz(
             box_position.x - box_size.x / 2.0,
@@ -107,8 +107,9 @@ pub fn setup_conversation(
             1.0,
         ),
         ..default()
-    }).insert(DialogueBox);
-	info!("Setting Up: GameState: Conversation");
+    }).insert(DialogueBox)
+      .insert(UserInput);
+	//info!("Setting Up: GameState: Conversation");
 }
 
 pub fn clear_conversation(
@@ -116,24 +117,24 @@ pub fn clear_conversation(
     mut clear_color: ResMut<ClearColor>,
     mut hero: Query<Entity, With<Hero>>,
 	mut enemy: Query<Entity, With<Enemy>>,
-    mut dialogue:Query<Entity,With<DialogueBox>>,
+    dialogue: Query<Entity, With<DialogueBox>>,
 
 ) {
     clear_color.0 = Color::BLACK;
-
+    for entity in dialogue.iter() {
+        commands.entity(entity).despawn();
+    }
     let hero_eid = hero.single_mut();
 	let enemy_eid = enemy.single_mut();
-    let dialogue_eid:Entity = dialogue.single_mut();
     commands.entity(hero_eid).despawn();
 	commands.entity(enemy_eid).despawn();
-    commands.entity(dialogue_eid).despawn();
 }
 
 pub fn text_input(
     mut char_evr: EventReader<ReceivedCharacter>,
     keys: Res<Input<KeyCode>>,
     mut string: Local<String>,
-	mut dialogue: Query<&mut Text, With<DialogueBox>>
+	mut dialogue: Query<&mut Text, With<UserInput>>
 ) {
 	let mut dialogue_text = dialogue.single_mut();
 

--- a/code/src/conversation.rs
+++ b/code/src/conversation.rs
@@ -9,6 +9,7 @@ pub struct Hero;
 pub struct Enemy;
 #[derive(Component)]
 pub struct DialogueBox;
+
 enum ConversationState {
     Introduction,
     Conversation,
@@ -20,19 +21,23 @@ enum ConversationState {
 pub fn setup_conversation(
 	mut commands: Commands,
 	mut clear_color: ResMut<ClearColor>, 
-	asset_server: Res<AssetServer>
+	asset_server: Res<AssetServer>,
 ){
     clear_color.0 = Color::DARK_GREEN;
-	let font = asset_server.load("Fonts/SourceSansPro-Regular.ttf");
-	let text_style = TextStyle {
-		font,
+    let user_text_style = TextStyle {
+		font: asset_server.load("Fonts/SourceSansPro-Regular.ttf"),
         font_size: 60.0,
         color: Color::WHITE
+    };
+    let enemy_text_style = TextStyle {
+		font: asset_server.load("Fonts/SourceSansPro-Regular.ttf"),
+        font_size: 60.0,
+        color: Color::BLACK
     };
 
     commands.spawn_bundle(SpriteBundle {
 		texture: asset_server.load("hero.png"),
-		transform: Transform::from_xyz(-200., 0., 2.),
+		transform: Transform::from_xyz(-500., -225., 2.),
 		sprite: Sprite {
             color: Color::BLUE,
             custom_size: Some(Vec2::new(200., 200.)),
@@ -40,9 +45,10 @@ pub fn setup_conversation(
         },
 		..default()
 	}).insert(Hero);
+
 	commands.spawn_bundle(SpriteBundle {
 		texture: asset_server.load("enemy.png"),
-		transform: Transform::from_xyz(200., 100., 2.),
+		transform: Transform::from_xyz(500., 200., 2.),
 		sprite: Sprite {
             color: Color::RED,
             custom_size: Some(Vec2::new(200., 200.)),
@@ -50,8 +56,10 @@ pub fn setup_conversation(
         },
 		..default()
 	}).insert(Enemy);
-	let box_size = Vec2::new(300.0, 200.0);
-    let box_position = Vec2::new(0.0, -250.0);
+
+	let box_size = Vec2::new(700.0, 200.0);
+    let box_position = Vec2::new(-45.0, -250.0);
+    let box_position_two = Vec2::new(45.0, 175.0);
 
     commands.spawn_bundle(SpriteBundle {
         sprite: Sprite {
@@ -62,9 +70,33 @@ pub fn setup_conversation(
         transform: Transform::from_translation(box_position.extend(0.0)),
         ..default()
     });
+
+    commands.spawn_bundle(SpriteBundle {
+        sprite: Sprite {
+            color: Color::WHITE,
+            custom_size: Some(Vec2::new(box_size.x, box_size.y)),
+            ..default()
+        },
+        transform: Transform::from_translation(box_position_two.extend(0.0)),
+        ..default()
+    });
+
+    commands.spawn_bundle(Text2dBundle {
+        text: Text::from_section("Excuse me neighbor, can I borrow some sugar?", enemy_text_style),
+        text_2d_bounds: Text2dBounds {
+            size: box_size,
+
+        },
+        transform: Transform::from_xyz(
+            box_position_two.x - box_size.x / 2.0,
+            box_position_two.y + box_size.y / 2.0,
+            1.0,
+        ),
+        ..default()
+    });
     
     commands.spawn_bundle(Text2dBundle {
-        text: Text::from_section("Press enter to display input", text_style),
+        text: Text::from_section("Press enter to display input", user_text_style),
         text_2d_bounds: Text2dBounds {
             size: box_size,
 
@@ -78,6 +110,7 @@ pub fn setup_conversation(
     }).insert(DialogueBox);
 	info!("Setting Up: GameState: Conversation");
 }
+
 pub fn clear_conversation(
     mut commands: Commands,
     mut clear_color: ResMut<ClearColor>,
@@ -94,12 +127,8 @@ pub fn clear_conversation(
     commands.entity(hero_eid).despawn();
 	commands.entity(enemy_eid).despawn();
     commands.entity(dialogue_eid).despawn();
-    
-
-
 }
 
-/// prints every char coming in; press enter to echo the full string
 pub fn text_input(
     mut char_evr: EventReader<ReceivedCharacter>,
     keys: Res<Input<KeyCode>>,

--- a/code/src/main.rs
+++ b/code/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
 			..default()
 		})
 		.insert_resource(ClearColor(Color::BLACK))
-		.add_state(GameState::Fight)	//start the game in the credits state
+		.add_state(GameState::Fight)	//start the game in the fight state
 		.add_plugins(DefaultPlugins)
 		.add_startup_system(setup)
 		.add_system_set(


### PR DESCRIPTION
I updated conversation.rs to add a white text box with a hard-coded prompt and moved the player, enemy, and respective boxes to a Pokémon-style setup. I increased the text box size as well. I also updated clear_conversation to despawn the player's boxes and text more efficiently than using single_mut() for every entity.